### PR TITLE
Add a simple corrupted samples/proofs detector

### DIFF
--- a/detector.py
+++ b/detector.py
@@ -1,0 +1,41 @@
+import random
+
+from py_ecc import optimized_bls12_381 as b
+
+from imported.fft import fft
+from imported.kzg_proofs import div, list_to_reverse_bit_order, get_root_of_unity
+from imported.multicombs import lincomb
+
+from setup import get_setup
+from shared import MODULUS, Sample, get_coset_factor
+from my_types import G1Point
+from verifier import get_aggregated_pairings
+
+
+def __detect_aggregated(samples: [Sample], commitments: [G1Point], begin: int, end: int) -> [int]:
+    """ Detect if any samples/proofs in range [begin, end) of the row are corrupted"""
+    # Obtain the pairings
+    pairing_left, pairing_right = get_aggregated_pairings(samples[begin:end], commitments, begin + 1)
+
+    # Do the pairing check
+    pairing_check = pairing_left * pairing_right
+    pairing = b.final_exponentiate(pairing_check)
+    if pairing == b.FQ12.one():
+        return []
+    elif end == begin + 1:
+        return [begin]
+    
+    # Split the samples and do binary search
+    mid = (begin + end) // 2
+    corrupted_list = __detect_aggregated(samples, commitments, begin, mid)
+    # TODO: The correctness of another half can be obtained by
+    #       pairing_left / pairing_left_of_left_samples == pairing_right / pairing_right_of_left_samples
+    corrupted_list += __detect_aggregated(samples, commitments, mid, end)
+    return corrupted_list
+
+
+def detect_aggregated(samples: [Sample], commitments: [G1Point]) -> [int]:
+    """
+    Detect if any samples/proofs are corrupted using binary search.
+    """
+    return __detect_aggregated(samples, commitments, 0, len(samples))

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ from prover import create_matrix
 from setup import generate_setup
 from shared import MODULUS, Sample
 from verifier import verify, verify_aggregated
+from detector import detect_aggregated
 
 from my_types import G1Point
 
@@ -35,3 +36,19 @@ class TestMatrix(TestCase):
     def test_verify_aggregated_sample_proofs(self):
         samples = [self.matrix[0][3], self.matrix[2][0], self.matrix[2][2], self.matrix[3][2]]
         self.assertTrue(verify_aggregated(samples, self.commitments))
+
+    def test_verify_aggregated_sample_proofs_with_corrupted_sample(self):
+        samples = [self.matrix[0][3], self.matrix[2][0], self.matrix[2][2], self.matrix[3][2]]
+        # corrupt one sample
+        samples[0].vs[0] += 1
+        self.assertFalse(verify_aggregated(samples, self.commitments))
+
+    def test_detect_aggregated_sample_proofs_(self):
+        samples = [self.matrix[0][3], self.matrix[2][0], self.matrix[2][2], self.matrix[3][2]]
+        # corrupt one sample
+        samples[0].vs[0] += 1
+        self.assertEqual(detect_aggregated(samples, self.commitments), [0])
+
+        # corrupt another sample
+        samples[3].vs[3] += 1
+        self.assertEqual(detect_aggregated(samples, self.commitments), [0, 3])


### PR DESCRIPTION
This detector implements a straightforward binary search to find corrupted samples and proofs.  It mostly relies on `get_aggregated_pairings` method, which is heavily modified from the original `verify` method.  A few tests are added to verify the results.

The code is not optimized, but it should illustrate the basic idea of locating the corrupted ones as we discussed last week.  In the worst case, the code will perform 4n-2 pairings to find all corrupted samples and/or proofs (e.g., in the case that all samples or proofs are corrupted).

A couple of optimizations can be done following this PR:
- The number of pairings may be further reduced to 2n-2 (see notes in the code).
- The linear combinations of elliptic curve points (e.g., proofs/commitments/etc) can be further optimized so that some combinations do not need to be re-calculated.